### PR TITLE
refactor: sliding window with stride, padding

### DIFF
--- a/src/iterdot/_helpers.py
+++ b/src/iterdot/_helpers.py
@@ -2,6 +2,7 @@ from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import wraps
 from itertools import chain, islice
+from operator import call
 from types import NoneType
 from typing import cast
 
@@ -18,6 +19,9 @@ def flatten(iterable: Iterable[object]) -> Iterable[object]:
             yield from flatten(cast(Iterable[object], item))
         else:
             yield item
+
+
+consume = deque[object](maxlen=0).extend
 
 
 def skip_take_by_order[**P, R](func: Callable[P, R]) -> Callable[P, R]:
@@ -63,31 +67,10 @@ def sliding_window_iter[T, F](
 ) -> Iterator[tuple[T, ...]] | Iterator[tuple[T | F, ...]]:
     match uneven:
         case Pad(fillvalue=pad):
-            window = deque[T | F](last := tuple(islice(it, n)), maxlen=n)
-            if not window:
-                return
-
-            if (wl := len(window)) < n:
-                yield tuple(window) + (pad,) * (wl - n)
-                return
-            while last:
-                yield tuple(window)
-                last = tuple(islice(it, stride))
-                ll = len(last)
-                if ll == stride:
-                    window.extend(last)
-                    continue
-                elif ll == 0:
-                    wl = len(window)
-                    while (wl := wl - stride) > 0:
-                        window.extend((pad,) * stride)
-                        yield tuple(window)
-                    return
-                else:
-                    if stride - ll >= n:
-                        return
-                    last += (pad,) * (stride - ll)
-                    window.extend(last)
+            yield from (
+                item if (il := len(item)) == n else (item + (pad,) * (n - il))
+                for item in sliding_window_iter(it, n, stride=stride, uneven=None)
+            )
         case Ignore():
             window = deque[T | F](last := tuple(islice(it, n)), maxlen=n)
             if not window:
@@ -112,34 +95,20 @@ def sliding_window_iter[T, F](
             if not window:
                 return
 
-            while last:
+            while True:
                 yield tuple(window)
-                last = tuple(islice(it, stride))
-                ll = len(last)
-                if ll == stride:
-                    window.extend(last)
-                    continue
-                elif ll == 0:
-                    wl = len(window)
-                    while (wl := wl - stride) > 0:
-                        yield tuple(window)[-wl:]
-                    return
-                else:
-                    if stride - ll >= n:
+                n1 = min(stride, len(window))
+                consume(map(call, [window.popleft] * n1))
+                stride_remaining = tuple(islice(it, stride - n1))
+                if stride - n1 > 0 and not stride_remaining:
+                    if not window:
                         return
-                    wl = len(window)
-                    while (wl := wl - stride) > 0:
-                        yield tuple(window)[-wl:]
-                    else:
-                        remainder = stride - len(window)
-                        while window:
-                            _ = window.popleft()
-                        window.extend(last)
-                        if remainder > 0:
-                            for _ in range(remainder):
-                                _ = window.popleft()
-                        yield tuple(window)
+                else:
+                    window.extend(islice(it, stride))
+                if not window:
                     return
+        case unknown:  # # pyright: ignore[reportUnnecessaryComparison]
+            raise ValueError(f"Received unknown value for uneven: {unknown!r}")  # pyright: ignore[reportUnreachable]
 
 
 def sliding_window_seq[T, F](
@@ -157,9 +126,8 @@ def sliding_window_seq[T, F](
     match uneven:
         case Pad(fillvalue=pad):
             if len(last) < n:
-                rest.append(last + (pad,) * (n - len(last)))
-            else:
-                rest.append(last)
+                last += (pad,) * (n - len(last))
+            rest.append(last)
             return rest
         case NoneType():
             return result

--- a/src/iterdot/_helpers.py
+++ b/src/iterdot/_helpers.py
@@ -143,3 +143,5 @@ def sliding_window_seq[T, F](
                 )
             rest.append(last)
             return rest
+        case unknown:  # # pyright: ignore[reportUnnecessaryComparison]
+            raise ValueError(f"Received unknown value for uneven: {unknown!r}")  # pyright: ignore[reportUnreachable]

--- a/src/iterdot/chain.py
+++ b/src/iterdot/chain.py
@@ -1107,18 +1107,18 @@ class Iter[T](Iterator[T]):
         This method provides three strategies for handling iterables of unequal length:
         1. Ignore (default): Stop when shortest iterable is exhausted
         2. Raise: Raise an error if iterables have unequal length
-        3. Fill: Use a fill value to pad the shorter iterable
+        3. Pad: Use a fill value to pad the shorter iterable
 
         Args:
             other: Second iterable to zip with
             missing_policy: Policy for handling unequal length iterables:
                 - Ignore(): Stop when shortest exhausted (default)
                 - Raise(): Raise error if lengths unequal
-                - Fill(value): Pad shorter with value
+                - Pad(value): Pad shorter with value
 
         Returns:
             Iter[tuple[T, R]]: Zipped iterator pairs
-            Iter[tuple[T | F, R | F]]: Zipped pairs with fill value type when using Fill policy
+            Iter[tuple[T | F, R | F]]: Zipped pairs with fill value type when using Pad policy
 
         Raises:
             ValueError: If iterables have unequal length and if_unequal=Raise()
@@ -1131,7 +1131,7 @@ class Iter[T](Iterator[T]):
             Traceback (most recent call last):
                 ...
             ValueError: zip() argument 2 is longer than argument 1
-            >>> Iter([1, 2]).zip([3], missing_policy=Fill(0)).to_list()
+            >>> Iter([1, 2]).zip([3], missing_policy=Pad(0)).to_list()
             [(1, 3), (2, 0)]
         """
         match missing_policy:
@@ -1143,7 +1143,7 @@ class Iter[T](Iterator[T]):
                 return Iter(it.zip_longest(self, other, fillvalue=fillvalue))
 
         raise ValueError(  # pyright: ignore[reportUnreachable]
-            f"{missing_policy=} not recognized. Choices: Raise | Ignore | Fill"
+            f"{missing_policy=} not recognized. Choices: Raise | Ignore | Pad"
         )
 
     @tp.overload

--- a/src/iterdot/chain.py
+++ b/src/iterdot/chain.py
@@ -6,37 +6,34 @@ import typing as tp
 from collections import deque
 from collections.abc import Callable, Generator, Iterable, Iterator, Sequence, Sized
 from contextlib import suppress
-from dataclasses import dataclass
 from decimal import Decimal
 from fractions import Fraction
-from functools import partial, reduce
+from functools import reduce
 from operator import add, attrgetter
 
-from iterdot._helpers import flatten, prepend, skip_take_by_order, sliding_window
-from iterdot.defaults import Default, Exhausted, NoDefault, Unavailable
+from iterdot._helpers import (
+    flatten,
+    prepend,
+    skip_take_by_order,
+    sliding_window_iter,
+    sliding_window_seq,
+)
+from iterdot.defaults import (
+    IGNORE,
+    Default,
+    Exhausted,
+    Ignore,
+    MissingPolicy,
+    NoDefault,
+    Pad,
+    Raise,
+    Unavailable,
+)
 from iterdot.index import Indexed
 from iterdot.minmax import MinMax, lazy_minmax, lazy_minmax_keyed
 from iterdot.operators import IsEqual, Unpacked
 from iterdot.plugins.stats import stats
 from iterdot.wtyping import Comparable, SupportsAdd, SupportsSumNoDefault
-
-
-@dataclass(frozen=True, slots=True)
-class Ignore: ...
-
-
-@dataclass(frozen=True, slots=True)
-class Raise: ...
-
-
-@dataclass(frozen=True, slots=True)
-class Fill[T]:
-    fillvalue: T
-
-
-IGNORE = Ignore()
-
-type MissingPolicy[T] = Ignore | Raise | Fill[T]
 
 
 @tp.final
@@ -1097,7 +1094,7 @@ class Iter[T](Iterator[T]):
     @tp.overload
     def zip[R](self: Iterable[T], other: Iterable[R], *, missing_policy: Raise) -> Iter[tuple[T, R]]: ...
     @tp.overload
-    def zip[R, F](self: Iterable[T], other: Iterable[R], *, missing_policy: Fill[F]) -> Iter[tuple[T | F, R | F]]: ...
+    def zip[R, F](self: Iterable[T], other: Iterable[R], *, missing_policy: Pad[F]) -> Iter[tuple[T | F, R | F]]: ...
     # fmt: on
     def zip[R, F](
         self: Iterable[T],
@@ -1142,7 +1139,7 @@ class Iter[T](Iterator[T]):
                 return Iter(zip(self, other, strict=True))
             case Ignore():
                 return Iter(zip(self, other, strict=False))
-            case Fill(fillvalue=fillvalue):
+            case Pad(fillvalue=fillvalue):
                 return Iter(it.zip_longest(self, other, fillvalue=fillvalue))
 
         raise ValueError(  # pyright: ignore[reportUnreachable]
@@ -1458,66 +1455,27 @@ class Iter[T](Iterator[T]):
             return enumerated.starmap(Indexed)
         return enumerated
 
-    # TODO: Consider complex padding: +ve int for left, -ve int for right, complex for left right
     @tp.overload
     def sliding_window(
-        self, n: int, *, fill_value: tp.Literal[Default.NoDefault] = NoDefault
+        self,
+        n: int,
+        *,
+        uneven: Raise | Ignore | None = None,
     ) -> Iter[tuple[T, ...]]: ...
     @tp.overload
     def sliding_window[F](
         self,
         n: int,
         *,
-        fill_value: F,
-        pad: tp.Literal["left", "right", "both"] = "left",
+        uneven: Pad[F],
     ) -> Iter[tuple[T | F, ...]]: ...
     def sliding_window[F](
         self,
         n: int,
         *,
-        fill_value: F | tp.Literal[Default.NoDefault] = NoDefault,
-        pad: tp.Literal["left", "right", "both"] = "both",
+        uneven: MissingPolicy[F] | None = None,
     ) -> Iter[tuple[T, ...]] | Iter[tuple[T | F, ...]]:
-        """
-        Sliding window over self.
-
-        Args:
-            n (int): Size of the window
-            fill_value (object, optional): If present, used for padding.
-            pad (str): 'left', 'right', or 'both'; indicating which side should be padded.
-
-        Returns:
-            Iter: Iter of n-tuples
-
-        Example:
-            >>> itbl = [1, 2, 3]
-            >>> Iter(itbl).sliding_window(2).to_list()
-            [(1, 2), (2, 3)]
-            >>> Iter(itbl).sliding_window(2, fill_value=0).to_list()
-            [(0, 1), (1, 2), (2, 3), (3, 0)]
-            >>> Iter(itbl).sliding_window(2, fill_value=0, pad="left").to_list()
-            [(0, 1), (1, 2), (2, 3)]
-            >>> Iter(itbl).sliding_window(2, fill_value=0, pad="right").to_list()
-            [(1, 2), (2, 3), (3, 0)]
-            >>> Iter(itbl).sliding_window(5).to_list()
-            [(1, 2, 3)]
-            >>> Iter(itbl).sliding_window(5, fill_value=0, pad="left").to_list()
-            [(0, 0, 0, 0, 1), (0, 0, 0, 1, 2), (0, 0, 1, 2, 3)]
-            >>> Iter([1]).sliding_window(3, fill_value=0).to_list()
-            [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
-        """
-        if fill_value is NoDefault:
-            return Iter(sliding_window(self, n))
-        if self.peek_next_value() is Exhausted:
-            return Iter[tuple[T, ...]]()
-
-        fill = partial(it.repeat, fill_value, n - 1)
-        padding = ["left", "right"] if pad == "both" else [pad]
-        if "left" in padding:
-            self = self.concat(fill(), self_position="back")
-        if "right" in padding:
-            self = self.concat(fill())
-        return self.sliding_window(n)
+        return Iter(sliding_window_iter(self, n, uneven=uneven))
 
     def product_with[T2](self, other: Iterable[T2]) -> Iter[tuple[T, T2]]:
         """Calculate the cartesian product with another iterable.
@@ -2319,67 +2277,27 @@ class SeqIter[T](Sequence[T]):
             case "back":
                 return SeqIter(result + self.iterable)
 
-    # TODO: Consider complex padding: +ve int for left, -ve int for right, complex for left right
-    # TODO: Consider left pad, right pad
     @tp.overload
     def sliding_window(
-        self, n: int, *, fill_value: tp.Literal[Default.NoDefault] = NoDefault
+        self,
+        n: int,
+        *,
+        uneven: Raise | Ignore | None = None,
     ) -> SeqIter[tuple[T, ...]]: ...
     @tp.overload
     def sliding_window[F](
         self,
         n: int,
         *,
-        fill_value: F,
-        pad: tp.Literal["left", "right", "both"] = "left",
+        uneven: Pad[F],
     ) -> SeqIter[tuple[T | F, ...]]: ...
     def sliding_window[F](
         self,
         n: int,
         *,
-        fill_value: F | tp.Literal[Default.NoDefault] = NoDefault,
-        pad: tp.Literal["left", "right", "both"] = "both",
+        uneven: MissingPolicy[F] | None = None,
     ) -> SeqIter[tuple[T, ...]] | SeqIter[tuple[T | F, ...]]:
-        """
-        Sliding window over self.
-
-        Args:
-            n (int): Size of the window
-            fill_value (object, optional): If present, used for padding.
-            pad (str): 'left', 'right', or 'both'; indicating which side should be padded.
-
-        Returns:
-            Iter: Iter of n-tuples
-
-        Example:
-            >>> itbl = [1, 2, 3]
-            >>> SeqIter(itbl).sliding_window(2).to_list()
-            [(1, 2), (2, 3)]
-            >>> SeqIter(itbl).sliding_window(2, fill_value=0).to_list()
-            [(0, 1), (1, 2), (2, 3), (3, 0)]
-            >>> SeqIter(itbl).sliding_window(2, fill_value=0, pad="left").to_list()
-            [(0, 1), (1, 2), (2, 3)]
-            >>> SeqIter(itbl).sliding_window(2, fill_value=0, pad="right").to_list()
-            [(1, 2), (2, 3), (3, 0)]
-            >>> SeqIter(itbl).sliding_window(5).to_list()
-            [(1, 2, 3)]
-            >>> SeqIter(itbl).sliding_window(5, fill_value=0, pad="left").to_list()
-            [(0, 0, 0, 0, 1), (0, 0, 0, 1, 2), (0, 0, 1, 2, 3)]
-            >>> SeqIter([1]).sliding_window(3, fill_value=0).to_list()
-            [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
-        """
-        if fill_value is NoDefault:
-            return SeqIter(sliding_window(self.iterable, n))
-        if self.first(default=Exhausted) is Exhausted:
-            return SeqIter[tuple[T, ...]]()
-
-        fill = (fill_value,) * (n - 1)
-        padding = ["left", "right"] if pad == "both" else [pad]
-        if "left" in padding:
-            self = SeqIter[T | F](fill + self.iterable)
-        if "right" in padding:
-            self = SeqIter[T | F](self.iterable + fill)
-        return self.sliding_window(n)
+        return SeqIter(sliding_window_seq(self, n, uneven=uneven))
 
     def feed_into[R, **P](
         self,

--- a/src/iterdot/defaults.py
+++ b/src/iterdot/defaults.py
@@ -1,4 +1,5 @@
 import enum
+from dataclasses import dataclass
 from typing import Literal
 
 
@@ -14,3 +15,21 @@ class Default(enum.Enum):
 Exhausted: Literal[Default.Exhausted] = Default.Exhausted
 NoDefault: Literal[Default.NoDefault] = Default.NoDefault
 Unavailable: Literal[Default.Unavailable] = Default.Unavailable
+
+
+@dataclass(frozen=True, slots=True)
+class Ignore: ...
+
+
+@dataclass(frozen=True, slots=True)
+class Raise: ...
+
+
+@dataclass(frozen=True, slots=True)
+class Pad[T]:
+    fillvalue: T
+
+
+IGNORE = Ignore()
+
+type MissingPolicy[T] = Ignore | Raise | Pad[T]

--- a/tests/iterdot/test__helpers.py
+++ b/tests/iterdot/test__helpers.py
@@ -1,0 +1,248 @@
+import pytest
+
+from iterdot._helpers import sliding_window_iter, sliding_window_seq
+from iterdot.defaults import Ignore, Pad, Raise
+
+
+def test_sliding_window_iter_none() -> None:
+    itbl = [1, 2, 3]
+    assert list(sliding_window_iter(iter(itbl), 2, stride=2, uneven=None)) == [
+        (1, 2),
+        (3,),
+    ]
+    assert list(sliding_window_iter(iter(itbl), 2)) == [
+        (1, 2),
+        (2, 3),
+        (3,),
+    ]
+    assert list(sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=2)) == [
+        (1, 2, 3),
+        (3, 4, 5),
+        (5,),
+    ]
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=3)
+    ) == [
+        (1, 2, 3),
+        (4, 5),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=4)
+    ) == [
+        (1, 2, 3),
+        (5,),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=5)
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+
+
+def test_sliding_window_iter_pad() -> None:
+    itbl = [1, 2, 3]
+    assert list(sliding_window_iter(iter(itbl), 2, stride=2, uneven=Pad(0))) == [
+        (1, 2),
+        (3, 0),
+    ]
+    assert list(sliding_window_iter(iter(itbl), 2, uneven=Pad(0))) == [
+        (1, 2),
+        (2, 3),
+        (3, 0),
+    ]
+    assert list(
+        sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=2, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+        (3, 4, 5),
+        (5, 0, 0),
+    ]
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=3, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+        (4, 5, 0),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=4, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+        (5, 0, 0),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=5, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+
+
+def test_sliding_window_iter_ignore() -> None:
+    itbl = [1, 2, 3]
+    assert list(sliding_window_iter(iter(itbl), 2, stride=2, uneven=Ignore())) == [
+        (1, 2),
+    ]
+    assert list(sliding_window_iter(iter(itbl), 2, uneven=Ignore())) == [
+        (1, 2),
+        (2, 3),
+    ]
+    assert list(
+        sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=2, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+        (3, 4, 5),
+    ]
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=3, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=4, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=5, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+
+
+def test_sliding_window_iter_raise() -> None:
+    itbl = [1, 2, 3]
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_iter(iter(itbl), 2, stride=2, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_iter(iter(itbl), 2, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=2, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=3, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=4, uneven=Raise()))
+    assert list(
+        sliding_window_iter(iter([1, 2, 3, 4, 5]), 3, stride=5, uneven=Raise())
+    ) == [
+        (1, 2, 3),
+    ]
+
+
+def test_sliding_window_seq_pad() -> None:
+    itbl = [1, 2, 3]
+    assert list(sliding_window_seq(tuple(itbl), 2, stride=2, uneven=Pad(0))) == [
+        (1, 2),
+        (3, 0),
+    ]
+    assert list(sliding_window_seq(tuple(itbl), 2, uneven=Pad(0))) == [
+        (1, 2),
+        (2, 3),
+        (3, 0),
+    ]
+    assert list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=2, uneven=Pad(0))) == [
+        (1, 2, 3),
+        (3, 4, 5),
+        (5, 0, 0),
+    ]
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=3, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+        (4, 5, 0),
+    ]  # fmt: skip
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=4, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+        (5, 0, 0),
+    ]  # fmt: skip
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=5, uneven=Pad(0))
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+
+
+def test_sliding_window_seq_none() -> None:
+    itbl = [1, 2, 3]
+    assert list(sliding_window_seq(tuple(itbl), 2, stride=2, uneven=None)) == [
+        (1, 2),
+        (3,),
+    ]
+    assert list(sliding_window_seq(tuple(itbl), 2)) == [
+        (1, 2),
+        (2, 3),
+        (3,),
+    ]
+    assert list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=2)) == [
+        (1, 2, 3),
+        (3, 4, 5),
+        (5,),
+    ]
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=3)
+    ) == [
+        (1, 2, 3),
+        (4, 5),
+    ]  # fmt: skip
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=4)
+    ) == [
+        (1, 2, 3),
+        (5,),
+    ]  # fmt: skip
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=5)
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+
+
+def test_sliding_window_seq_ignore() -> None:
+    itbl = [1, 2, 3]
+    assert list(sliding_window_seq(tuple(itbl), 2, stride=2, uneven=Ignore())) == [
+        (1, 2),
+    ]
+    assert list(sliding_window_seq(tuple(itbl), 2, uneven=Ignore())) == [
+        (1, 2),
+        (2, 3),
+    ]
+    assert list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=2, uneven=Ignore())) == [
+        (1, 2, 3),
+        (3, 4, 5),
+    ]
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=3, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=4, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+    assert list(sliding_window_seq(
+        (1, 2, 3, 4, 5), 3, stride=5, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+    ]  # fmt: skip
+
+
+def test_sliding_window_seq_raise() -> None:
+    itbl = [1, 2, 3]
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_seq(tuple(itbl), 2, stride=2, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_seq(tuple(itbl), 2, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        assert list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=2, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=3, uneven=Raise()))
+    with pytest.raises(ValueError, match="shorter than specified n"):
+        _ = list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=4, uneven=Raise()))
+    assert list(sliding_window_seq((1, 2, 3, 4, 5), 3, stride=5, uneven=Raise())) == [
+        (1, 2, 3),
+    ]
+    assert list(sliding_window_seq((1, 2, 3, 4, 5, 6), 3, stride=3, uneven=Raise())) == [
+        (1, 2, 3),
+        (4, 5, 6),
+    ]

--- a/tests/iterdot/test__helpers.py
+++ b/tests/iterdot/test__helpers.py
@@ -37,6 +37,15 @@ def test_sliding_window_iter_none() -> None:
     ) == [
         (1, 2, 3),
     ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=1)
+    ) == [
+        (1, 2, 3),
+        (2, 3, 4),
+        (3, 4, 5),
+        (4, 5),
+        (5,),
+    ]  # fmt: skip
 
 
 def test_sliding_window_iter_pad() -> None:
@@ -105,6 +114,13 @@ def test_sliding_window_iter_ignore() -> None:
         iter([1, 2, 3, 4, 5]), 3, stride=5, uneven=Ignore())
     ) == [
         (1, 2, 3),
+    ]  # fmt: skip
+    assert list(sliding_window_iter(
+        iter([1, 2, 3, 4, 5]), 3, stride=1, uneven=Ignore())
+    ) == [
+        (1, 2, 3),
+        (2, 3, 4),
+        (3, 4, 5),
     ]  # fmt: skip
 
 

--- a/tests/iterdot/test_chain.py
+++ b/tests/iterdot/test_chain.py
@@ -7,8 +7,8 @@ from typing import Any, no_type_check
 
 import pytest
 
-from iterdot.chain import Fill, Iter, Raise, SeqIter
-from iterdot.defaults import Default
+from iterdot.chain import Iter, SeqIter
+from iterdot.defaults import Default, Pad, Raise
 
 
 def consume(iterable: Iterable[Any]):
@@ -159,7 +159,7 @@ def test_zip():
     assert Iter(range(4)).zip(range(5, 10)).to_list() == list(
         zip(range(4), range(5, 10), strict=False)
     )
-    assert Iter(range(4)).zip(range(5, 10), missing_policy=Fill(None)).to_list() == list(
+    assert Iter(range(4)).zip(range(5, 10), missing_policy=Pad(None)).to_list() == list(
         itl.zip_longest(range(4), range(5, 10), fillvalue=None)
     )
     with pytest.raises(ValueError, match="shorter|longer"):

--- a/uv.lock
+++ b/uv.lock
@@ -51,11 +51,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.1"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bb/25024dbcc93516c492b75919e76f389bac754a3e4248682fba32b250c880/identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98", size = 99097 }
+sdist = { url = "https://files.pythonhosted.org/packages/02/79/7a520fc5011e02ca3f3285b5f6820eaf80443eb73e3733f73c02fb42ba0b/identify-2.6.2.tar.gz", hash = "sha256:fab5c716c24d7a789775228823797296a2994b075fb6080ac83a102772a98cbd", size = 99113 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/0c/4ef72754c050979fdcc06c744715ae70ea37e734816bb6514f79df77a42f/identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0", size = 98972 },
+    { url = "https://files.pythonhosted.org/packages/e0/86/c4395700f3c5475424fb5c41e20c16be28d10c904aee4d005ba3217fc8e7/identify-2.6.2-py2.py3-none-any.whl", hash = "sha256:c097384259f49e372f4ea00a19719d95ae27dd5ff0fd77ad630aa891306b82f3", size = 98982 },
 ]
 
 [[package]]
@@ -208,6 +208,7 @@ wheels = [
 name = "ruff"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/06/09d1276df977eece383d0ed66052fc24ec4550a61f8fbc0a11200e690496/ruff-0.7.3.tar.gz", hash = "sha256:e1d1ba2e40b6e71a61b063354d04be669ab0d39c352461f3d789cac68b54a313", size = 3243664 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/56/933d433c2489e4642487b835f53dd9ff015fb3d8fa459b09bb2ce42d7c4b/ruff-0.7.3-py3-none-linux_armv6l.whl", hash = "sha256:34f2339dc22687ec7e7002792d1f50712bf84a13d5152e75712ac08be565d344", size = 10372090 },
     { url = "https://files.pythonhosted.org/packages/20/ea/1f0a22a6bcdd3fc26c73f63a025d05bd565901b729d56bcb093c722a6c4c/ruff-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fb397332a1879b9764a3455a0bb1087bda876c2db8aca3a3cbb67b3dbce8cda0", size = 10190037 },
@@ -221,6 +222,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/7b/1daa712de1c5bc6cbbf9fa60e9c41cc48cda962dc6d2c4f2a224d2c3007e/ruff-0.7.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8963cab06d130c4df2fd52c84e9f10d297826d2e8169ae0c798b6221be1d1d2", size = 11010091 },
     { url = "https://files.pythonhosted.org/packages/b6/db/1227a903587432eb569e57a95b15a4f191a71fe315cde4c0312df7bc85da/ruff-0.7.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:61b46049d6edc0e4317fb14b33bd693245281a3007288b68a3f5b74a22a0746d", size = 10610687 },
     { url = "https://files.pythonhosted.org/packages/db/e2/dc41ee90c3085aadad4da614d310d834f641aaafddf3dfbba08210c616ce/ruff-0.7.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:10ebce7696afe4644e8c1a23b3cf8c0f2193a310c18387c06e583ae9ef284de2", size = 10254843 },
+    { url = "https://files.pythonhosted.org/packages/6f/09/5f6cac1c91542bc5bd33d40b4c13b637bf64d7bb29e091dadb01b62527fe/ruff-0.7.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3f36d56326b3aef8eeee150b700e519880d1aab92f471eefdef656fd57492aa2", size = 10730962 },
+    { url = "https://files.pythonhosted.org/packages/d3/42/89a4b9a24ef7d00269e24086c417a006f9a3ffeac2c80f2629eb5ce140ee/ruff-0.7.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5d024301109a0007b78d57ab0ba190087b43dce852e552734ebf0b0b85e4fb16", size = 11101907 },
+    { url = "https://files.pythonhosted.org/packages/b0/5c/efdb4777686683a8edce94ffd812783bddcd3d2454d38c5ac193fef7c500/ruff-0.7.3-py3-none-win32.whl", hash = "sha256:4ba81a5f0c5478aa61674c5a2194de8b02652f17addf8dfc40c8937e6e7d79fc", size = 8611095 },
+    { url = "https://files.pythonhosted.org/packages/bb/b8/28fbc6a4efa50178f973972d1c84b2d0a33cdc731588522ab751ac3da2f5/ruff-0.7.3-py3-none-win_amd64.whl", hash = "sha256:588a9ff2fecf01025ed065fe28809cd5a53b43505f48b69a1ac7707b1b7e4088", size = 9418283 },
+    { url = "https://files.pythonhosted.org/packages/3f/77/b587cba6febd5e2003374f37eb89633f79f161e71084f94057c8653b7fb3/ruff-0.7.3-py3-none-win_arm64.whl", hash = "sha256:1713e2c5545863cdbfe2cbce21f69ffaf37b813bfd1fb3b90dc9a6f1963f5a8c", size = 8725228 },
 ]
 
 [[package]]


### PR DESCRIPTION
Simplify logic for sliding window. Break the function in two for iter and seqiter.